### PR TITLE
Lowered the level of some debugging output in lib/net.js file

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -90,7 +90,7 @@ module.exports = {
 				}
 			};
 
-			logger.info('conn');
+			logger.debug('conn');
 			connected = true;
 
 			plug = function(data) {
@@ -101,7 +101,7 @@ module.exports = {
 			}
 
 		}).on('reconnect', function(n, delay) {
-			logger.info('re-conn');
+			logger.debug('re-conn');
 		}).on('disconnect', function(err) {
 			if(connected) {
 				aggregator.removeListener('data', plug);


### PR DESCRIPTION
In order to minimize the volume of debugging output generated by the reconnect-net library.
